### PR TITLE
Update Travis to skip install phases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,12 @@ jobs:
       script: swift build
     - stage: "Test"
       name: "Unit tests"
+      install: skip
       script: swift test
     - stage: "Test"
       name: "pod lib lint"
       if: type = pull_request
+      install: skip
       script: bundle exec pod lib lint
     - stage: "Test"
       name: "Danger"
@@ -31,6 +33,7 @@ jobs:
       script: swift run danger-swift ci
     - stage: "Deploy"
       name: "GitHub Release"
+      install: skip
       script: skip
       before_deploy: carthage build --archive --cache-builds --platform iOS
       deploy:
@@ -41,6 +44,7 @@ jobs:
         skip_cleanup: true
     - stage: "Deploy"
       name: "CocoaPods release"
+      install: skip
       script: skip
       deploy:
         provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,8 +43,7 @@ jobs:
         skip_cleanup: true
     - stage: "Deploy"
       name: "CocoaPods release"
-      install: skip
       script: skip
       deploy:
         provider: script
-        script: pod trunk push
+        script: bundle exec pod trunk push

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ jobs:
     - stage: "Test"
       name: "pod lib lint"
       if: type = pull_request
-      install: skip
       script: bundle exec pod lib lint
     - stage: "Test"
       name: "Danger"


### PR DESCRIPTION
The point of the Prepare Cache stage is to do this, and Travis will run `bundle install…` when it detects the Gemfile