### PR TITLE
Remove SwiftPM cache on macOS

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,13 +21,6 @@ jobs:
     - name: yarn install
       run: yarn install
 
-    - name: Cache SwiftPM
-      uses: actions/cache@v1
-      with:
-        path: .build
-        key: ${{ runner.os }}-swiftpm-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-swiftpm-
     - name: Build Danger and Danger Dependencies
       run: swift build --skip-update --target DangerDependencies
     - name: Run Danger

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,13 +17,6 @@ jobs:
     - name: Select Xcode ${{ matrix.xcode }}
       run: sudo xcode-select --switch /Applications/Xcode_${{ matrix.xcode }}.app
 
-    - name: Cache SwiftPM
-      uses: actions/cache@v1
-      with:
-        path: .build
-        key: ${{ runner.os }}-xcode_${{ matrix.xcode }}-swiftpm-${{ hashFiles('**/Package.resolved') }}
-        restore-keys: |
-          ${{ runner.os }}-xcode_${{ matrix.xcode }}-swiftpm-
     - name: SwiftPM tests
       run: swift test --skip-update
 


### PR DESCRIPTION
Having the cache causes the build to fail because the path of the runner has changed. See https://github.com/actions/virtual-environments/issues/137.